### PR TITLE
fixed type checking reuse bug

### DIFF
--- a/AoE2ScenarioParser/datasets/techs.py
+++ b/AoE2ScenarioParser/datasets/techs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from enum import Enum
+import copy
 
 
 class TechInfo(Enum):
@@ -198,7 +199,7 @@ class TechInfo(Enum):
             A list of unique unite upgrade tech IDs
         """
         args = locals()
-        params = TechInfo.unique_unit_upgrades.__annotations__
+        params = copy.deepcopy(TechInfo.unique_unit_upgrades.__annotations__)
         params.pop("return")
         for param, param_type in params.items():
             provided = type(args[param]).__name__

--- a/AoE2ScenarioParser/datasets/units.py
+++ b/AoE2ScenarioParser/datasets/units.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from AoE2ScenarioParser.datasets.support.info_dataset_base import InfoDatasetBase
-
+import copy
 
 class UnitInfo(InfoDatasetBase):
     """
@@ -57,7 +57,7 @@ class UnitInfo(InfoDatasetBase):
             A list of villager UnitInfo objects
         """
         args = locals()
-        params = UnitInfo.vils.__annotations__
+        params = copy.deepcopy(UnitInfo.vils.__annotations__)
         params.pop("return")
         for param, param_type in params.items():
             provided = type(args[param]).__name__
@@ -120,7 +120,7 @@ class UnitInfo(InfoDatasetBase):
             A list of unique unit UniInfo objects
         """
         args = locals()
-        params = UnitInfo.unique_units.__annotations__
+        params = copy.deepcopy(UnitInfo.unique_units.__annotations__)
         params.pop("return")
         for param, param_type in params.items():
             provided = type(args[param]).__name__


### PR DESCRIPTION
The filter functions can't be reused atm because I modify their references, not their copies. That means when the function is called the 2nd time, the function tries to pop out an element that does not exist, leading to a KeyError.