### PR TITLE
Fix armor attack class for modify attribute effects

### DIFF
--- a/AoE2ScenarioParser/datasets/effects.py
+++ b/AoE2ScenarioParser/datasets/effects.py
@@ -689,6 +689,7 @@ class EffectId(IntEnum):
     - object_attributes
     - variable
     - message
+    - armour_attack_class
     
     **Version notice**: \n
     This effect was added in: 1.51 & Trigger Version 3.5
@@ -763,6 +764,7 @@ class EffectId(IntEnum):
     - object_attributes
     - variable
     - message
+    - armour_attack_class
 
     **Version notice**: \n
     This effect was added in: 1.54 & Trigger Version 3.9

--- a/AoE2ScenarioParser/objects/data_objects/effect.py
+++ b/AoE2ScenarioParser/objects/data_objects/effect.py
@@ -177,7 +177,7 @@ class Effect(AoE2Object, TriggerComponent):
 
         if self._armour_attack_source == 'variable':
             # If effect created through reading scenario file
-            if _variable_ref is not None and armour_attack_class is None:
+            if _variable_ref is not None and variable is None and armour_attack_class is None:
                 armour_attack_class, variable = self._quantity_to_aa(_variable_ref)
             # If created through new_effect with variable and armour_attack_class values
             else:

--- a/AoE2ScenarioParser/objects/data_objects/effect.py
+++ b/AoE2ScenarioParser/objects/data_objects/effect.py
@@ -178,14 +178,14 @@ class Effect(AoE2Object, TriggerComponent):
         if self._armour_attack_source == 'variable':
             # If effect created through reading scenario file
             if _variable_ref is not None and variable is None and armour_attack_class is None:
-                armour_attack_class, variable = self._quantity_to_aa(_variable_ref)
+                armour_attack_class, variable = self._split_aa_value(_variable_ref)
             # If created through new_effect with variable and armour_attack_class values
             else:
                 pass
         elif self._armour_attack_source == 'quantity':
             # If effect created through reading scenario file
             if quantity is not None and armour_attack_class is None and armour_attack_quantity is None:
-                armour_attack_class, armour_attack_quantity = self._quantity_to_aa(quantity)
+                armour_attack_class, armour_attack_quantity = self._split_aa_value(quantity)
                 quantity = None
             # If effect created through new_effect with aa values defined
             elif value_is_valid(armour_attack_class) or value_is_valid(armour_attack_quantity):
@@ -347,7 +347,7 @@ class Effect(AoE2Object, TriggerComponent):
     def quantity(self) -> int:
         """Getter for quantity, even if it is combined with `armour_attack_quantity` and `armour_attack_class`"""
         if self._armour_attack_source == 'quantity':
-            return self._aa_to_quantity(self.armour_attack_quantity, self.armour_attack_class)
+            return self._merge_aa_values(self.armour_attack_class, self.armour_attack_quantity)
         return self._quantity
 
     @quantity.setter
@@ -360,14 +360,14 @@ class Effect(AoE2Object, TriggerComponent):
                         "and 'effect.armour_attack_class' attributes instead.",
                 category=IncorrectArmorAttackUsageWarning
             )
-            self.armour_attack_class, self.armour_attack_quantity = self._quantity_to_aa(value)
+            self.armour_attack_class, self.armour_attack_quantity = self._split_aa_value(value)
         self._quantity = value
 
     @property
     def _variable_ref(self) -> int | None:
         """Variable only used for byte retrieval of Effect"""
         if self._armour_attack_source == 'variable':
-            return self._aa_to_quantity(self.variable, self.armour_attack_class)
+            return self._merge_aa_values(self.armour_attack_class, self.variable)
         return self.variable
 
     @property
@@ -431,7 +431,7 @@ class Effect(AoE2Object, TriggerComponent):
     def _update_armour_attack_flag(self):
         self._armour_attack_source = _get_armour_attack_source(self.effect_type, self.object_attributes)
 
-    def _quantity_to_aa(self, quantity: int) -> Tuple[int, int]:
+    def _split_aa_value(self, quantity: int) -> Tuple[int, int]:
         """
         A function to convert the initial quantity value to the quantity and armor/attack values.
         Unfortunately this problem has to be solved in the object due to how specific this was implemented in DE.
@@ -467,7 +467,7 @@ class Effect(AoE2Object, TriggerComponent):
             return quantity >> 16, quantity & 65535
         return quantity >> 8, quantity & 255
 
-    def _aa_to_quantity(self, aa_quantity: int, aa_class: int) -> int:
+    def _merge_aa_values(self, aa_class: int, aa_quantity: int) -> int:
         """
         A function to convert the quantity and armor/attack field to a quantity value.
         Unfortunately this problem has to be solved in the object due to how specific this was implemented in DE.

--- a/AoE2ScenarioParser/objects/support/new_effect.py
+++ b/AoE2ScenarioParser/objects/support/new_effect.py
@@ -1568,11 +1568,12 @@ class NewEffectSupport:
             message: str | None = None,
             armour_attack_class: int | None = None,
     ):
-        if (armour_attack_class is not None and object_attributes != ObjectAttribute.ATTACK and
-                object_attributes != ObjectAttribute.ARMOR):
+        if armour_attack_class is not None and object_attributes not in (ObjectAttribute.ATTACK, ObjectAttribute.ARMOR):
             raise ValueError("Cannot use 'armour_attack_class' for non attack/armor attributes.")
-        effect = self._trigger_ref._add_effect(
+
+        return self._trigger_ref._add_effect(
             EffectId.MODIFY_ATTRIBUTE_BY_VARIABLE,
+            armour_attack_class=armour_attack_class,
             object_list_unit_id=object_list_unit_id,
             source_player=source_player,
             operation=operation,
@@ -1580,11 +1581,6 @@ class NewEffectSupport:
             variable=variable,
             message=message,
         )
-        if armour_attack_class is not None and armour_attack_class > -1:
-            combined_var = effect._aa_to_quantity(variable, armour_attack_class)
-            effect.variable = combined_var
-
-        return effect
 
     def set_object_cost(
             self,
@@ -1685,12 +1681,12 @@ class NewEffectSupport:
             message: str | None = None,
             armour_attack_class: int | None = None,
     ):
-        if (armour_attack_class is not None and object_attributes != ObjectAttribute.ATTACK and
-                object_attributes != ObjectAttribute.ARMOR):
+        if armour_attack_class is not None and object_attributes not in (ObjectAttribute.ATTACK, ObjectAttribute.ARMOR):
             raise ValueError("Cannot use 'armour_attack_class' for non attack/armor attributes.")
 
-        effect = self._trigger_ref._add_effect(
+        return self._trigger_ref._add_effect(
             EffectId.MODIFY_VARIABLE_BY_ATTRIBUTE,
+            armour_attack_class=armour_attack_class,
             object_list_unit_id=object_list_unit_id,
             source_player=source_player,
             operation=operation,
@@ -1698,11 +1694,6 @@ class NewEffectSupport:
             variable=variable,
             message=message
         )
-        if armour_attack_class is not None and armour_attack_class > -1:
-            combined_var = effect._aa_to_quantity(variable, armour_attack_class)
-            effect.variable = combined_var
-
-        return effect
 
     def change_object_caption(
             self,

--- a/AoE2ScenarioParser/objects/support/new_effect.py
+++ b/AoE2ScenarioParser/objects/support/new_effect.py
@@ -1580,7 +1580,7 @@ class NewEffectSupport:
             variable=variable,
             message=message,
         )
-        if object_attributes == ObjectAttribute.ATTACK or object_attributes == ObjectAttribute.ARMOR:
+        if armour_attack_class is not None and armour_attack_class > -1:
             combined_var = effect._aa_to_quantity(variable, armour_attack_class)
             effect.variable = combined_var
 
@@ -1698,7 +1698,7 @@ class NewEffectSupport:
             variable=variable,
             message=message
         )
-        if object_attributes == ObjectAttribute.ATTACK or object_attributes == ObjectAttribute.ARMOR:
+        if armour_attack_class is not None and armour_attack_class > -1:
             combined_var = effect._aa_to_quantity(variable, armour_attack_class)
             effect.variable = combined_var
 

--- a/AoE2ScenarioParser/objects/support/new_effect.py
+++ b/AoE2ScenarioParser/objects/support/new_effect.py
@@ -5,6 +5,7 @@ from typing import List
 from typing_extensions import deprecated
 
 from AoE2ScenarioParser.datasets.effects import EffectId
+from AoE2ScenarioParser.datasets.trigger_lists import ObjectAttribute
 from AoE2ScenarioParser.objects.data_objects.effect import Effect
 
 
@@ -1565,16 +1566,25 @@ class NewEffectSupport:
             object_attributes: int | None = None,
             variable: int | None = None,
             message: str | None = None,
+            armour_attack_class: int | None = None,
     ):
-        return self._trigger_ref._add_effect(
+        if (armour_attack_class is not None and object_attributes != ObjectAttribute.ATTACK and
+                object_attributes != ObjectAttribute.ARMOR):
+            raise ValueError("Cannot use 'armour_attack_class' for non attack/armor attributes.")
+        effect = self._trigger_ref._add_effect(
             EffectId.MODIFY_ATTRIBUTE_BY_VARIABLE,
             object_list_unit_id=object_list_unit_id,
             source_player=source_player,
             operation=operation,
             object_attributes=object_attributes,
             variable=variable,
-            message=message
+            message=message,
         )
+        if object_attributes == ObjectAttribute.ATTACK or object_attributes == ObjectAttribute.ARMOR:
+            combined_var = effect._aa_to_quantity(variable, armour_attack_class)
+            effect.variable = combined_var
+
+        return effect
 
     def set_object_cost(
             self,
@@ -1673,8 +1683,13 @@ class NewEffectSupport:
             object_attributes: int | None = None,
             variable: int | None = None,
             message: str | None = None,
+            armour_attack_class: int | None = None,
     ):
-        return self._trigger_ref._add_effect(
+        if (armour_attack_class is not None and object_attributes != ObjectAttribute.ATTACK and
+                object_attributes != ObjectAttribute.ARMOR):
+            raise ValueError("Cannot use 'armour_attack_class' for non attack/armor attributes.")
+
+        effect = self._trigger_ref._add_effect(
             EffectId.MODIFY_VARIABLE_BY_ATTRIBUTE,
             object_list_unit_id=object_list_unit_id,
             source_player=source_player,
@@ -1683,6 +1698,11 @@ class NewEffectSupport:
             variable=variable,
             message=message
         )
+        if object_attributes == ObjectAttribute.ATTACK or object_attributes == ObjectAttribute.ARMOR:
+            combined_var = effect._aa_to_quantity(variable, armour_attack_class)
+            effect.variable = combined_var
+
+        return effect
 
     def change_object_caption(
             self,

--- a/AoE2ScenarioParser/versions/DE/v1.54/effects.json
+++ b/AoE2ScenarioParser/versions/DE/v1.54/effects.json
@@ -5431,7 +5431,9 @@
             "operation",
             "object_attributes",
             "variable",
-            "message"
+            "message",
+            "string_id",
+            "armour_attack_class"
         ],
         "default_attributes": {
             "effect_type": 87,

--- a/AoE2ScenarioParser/versions/DE/v1.54/effects.json
+++ b/AoE2ScenarioParser/versions/DE/v1.54/effects.json
@@ -5275,7 +5275,8 @@
             "operation",
             "object_attributes",
             "variable",
-            "message"
+            "message",
+            "armour_attack_class"
         ],
         "default_attributes": {
             "effect_type": 79,
@@ -5432,7 +5433,6 @@
             "object_attributes",
             "variable",
             "message",
-            "string_id",
             "armour_attack_class"
         ],
         "default_attributes": {


### PR DESCRIPTION
these 2 effects combine variable and armor/attack type into 1 var `variable`. there the least significant bits are used for variable and the most significant bits for the atk/armor class. an int is split into 2 bytes for each it seems.