### PR TITLE
raise a exception when try to save a illegal None attribute

### DIFF
--- a/AoE2ScenarioParser/sections/retrievers/retriever.py
+++ b/AoE2ScenarioParser/sections/retrievers/retriever.py
@@ -99,6 +99,8 @@ class Retriever:
                     raise e
 
             joined_result = b''.join(result)
+        elif self.data is None and self.datatype.repeat != 0:
+            raise ValueError(f"Unable to convert NoneType with non-zero repeat to bytes (Attribute: {self.name})")
         else:
             joined_result = b''
 


### PR DESCRIPTION
During the issues recently, a quantity with None value might be save to file without any exception, and corrupt the scenario.
We can raise an exception in this situation to prevent creating a corrupted file again in the future.